### PR TITLE
feat(docusaurus.config): add trailingSlash configuration

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
   url: 'https://colore.mallikcheripally.com',
   baseUrl: '/',
+  trailingSlash: false,
   organizationName: 'mallikcheripally',
   projectName: 'colore-js',
   onBrokenLinks: 'throw',


### PR DESCRIPTION
A trailingSlash configuration has been added to the docusaurus.config.ts file. This ensures that a trailing slash is not included in generated site URLs, improving URL consistency across the site.