### PR TITLE
feat: add setAlphaValue function and related tests

### DIFF
--- a/docs/docs/api/manipulations/setAlphaValue.mdx
+++ b/docs/docs/api/manipulations/setAlphaValue.mdx
@@ -1,0 +1,65 @@
+---
+id: setAlphaValue
+title: setAlphaValue
+description: "Learn how to use the setAlphaValue function in Colore JS to set the alpha value of a given color in various formats. This guide covers the syntax, parameters, examples, and practical applications for adjusting color transparency in your projects."
+keywords:
+  - colore-js
+  - colore
+  - colore js
+  - setAlphaValue
+  - alpha value
+  - set alpha
+  - color transparency
+  - css color
+  - javascript color manipulation
+  - color manipulation
+---
+
+import StructuredData from '@site/src/components/StructuredData';
+
+<StructuredData />
+
+# setAlphaValue
+
+The `setAlphaValue` function sets the alpha value of a given color in various formats. This is useful for adjusting the transparency of colors.
+
+## Syntax
+
+```typescript
+setAlphaValue(color: string, alpha: number): string;
+```
+
+### Parameters
+
+- **`color`** (string): The input color string in any supported format (hex, rgb, hsl, etc.).
+- **`alpha`** (number): The alpha value to set (0-1).
+
+### Returns
+
+- **string**: The color with the new alpha value in the original format.
+
+### Throws
+
+- **Error**: Throws an error if the input color format is invalid or if the alpha value is out of range.
+
+## Example
+
+```typescript
+import { setAlphaValue } from 'colore-js';
+
+const rgbaColor = setAlphaValue('#ff0000', 0.5);
+console.log(rgbaColor);
+// Output: '#ff000080'
+
+const rgbaColorFromRgb = setAlphaValue('rgb(255, 0, 0)', 0.5);
+console.log(rgbaColorFromRgb);
+// Output: 'rgba(255, 0, 0, 0.5)'
+
+const hslaColor = setAlphaValue('hsl(0, 100%, 50%)', 0.5);
+console.log(hslaColor);
+// Output: 'hsla(0, 100%, 50%, 0.5)'
+```
+
+## Usage
+
+The `setAlphaValue` function is used to adjust the transparency of colors in various formats. This can be useful in web design, data visualization, and other applications where color manipulation is required.

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export { saturateColor } from '@/manipulations/saturateColor';
 export { desaturateColor } from '@/manipulations/desaturateColor';
 export { blendColors } from '@/manipulations/blendColors';
 export { invertColor } from '@/manipulations/invertColor';
+export { setAlphaValue } from '@/manipulations/setAlphaValue';
 
 
 // Utils

--- a/src/manipulations/setAlphaValue.ts
+++ b/src/manipulations/setAlphaValue.ts
@@ -1,0 +1,55 @@
+import { detectColorFormat } from '@/parser/detectColorFormat';
+import { decomposeColor } from '@/parser/decomposeColor';
+import { recomposeColor } from '@/parser/recomposeColor';
+import { parseColorToRgba } from '@/parser/parseColorToRgba';
+import { ColorFormats } from '@/utils/colorFormats';
+import { parseRgb } from '@/parser/parseRgb';
+import { rgbToRgba } from '@/conversions/rgbToRgba';
+import { parseHsl } from '@/parser/parseHsl';
+import { hslToHsla } from '@/conversions/hslToHsla';
+import { hexToHexAlpha } from '@/conversions/hexToHexAlpha';
+import { parseNamedColor } from '@/parser/parseNamedColor';
+
+/**
+ * Sets the alpha value of a given color.
+ *
+ * @param {string} color - The input color string in any supported format (hex, rgb, hsl, etc.).
+ * @param {number} alpha - The alpha value to set (0-1).
+ * @returns {string} - The color with the new alpha value in the original format.
+ * @throws {Error} - Throws an error if the input color format is invalid or if the alpha value is out of range.
+ */
+export function setAlphaValue(color: string, alpha: number): string {
+    if (alpha < 0 || alpha > 1) {
+        throw new Error(`Invalid alpha value ${alpha}. Alpha should be between 0 and 1.`);
+    }
+
+    const format = detectColorFormat(color);
+    const decomposed = decomposeColor(color);
+
+    switch (format) {
+        case ColorFormats.RGBA:
+        case ColorFormats.HSLA:
+        case ColorFormats.HEX_ALPHA:
+            decomposed.a = alpha;
+            break;
+        case ColorFormats.RGB:
+            const rgb = parseRgb(color);
+            return rgbToRgba(rgb.r, rgb.g, rgb.b, alpha);
+        case ColorFormats.HSL:
+            const hsl = parseHsl(color);
+            return hslToHsla(hsl.hDeg, hsl.s, hsl.l, alpha);
+        case ColorFormats.HEX:
+            return hexToHexAlpha(color, alpha);
+        case ColorFormats.LAB:
+        case ColorFormats.LCH: {
+            const rgba = parseColorToRgba(color);
+            return `rgba(${rgba.r}, ${rgba.g}, ${rgba.b}, ${alpha})`;
+        }
+        case ColorFormats.NAMED: {
+            const namedColor = parseNamedColor(color);
+            return rgbToRgba(namedColor.r, namedColor.g, namedColor.b, alpha);
+        }
+    }
+
+    return recomposeColor(color, decomposed);
+}

--- a/tests/manipulations/setAlphaValue.test.ts
+++ b/tests/manipulations/setAlphaValue.test.ts
@@ -1,0 +1,57 @@
+import { setAlphaValue } from '@/manipulations/setAlphaValue';
+
+describe('setAlphaValue', () => {
+    test('sets alpha value for RGBA color', () => {
+        expect(setAlphaValue('rgba(255, 0, 0, 0.5)', 0.8)).toBe('rgba(255, 0, 0, 0.8)');
+        expect(setAlphaValue('rgba(0, 255, 0, 0.3)', 0.5)).toBe('rgba(0, 255, 0, 0.5)');
+    });
+
+    test('sets alpha value for HSLA color', () => {
+        expect(setAlphaValue('hsla(120, 100%, 50%, 0.5)', 0.8)).toBe('hsla(120, 100%, 50%, 0.8)');
+        expect(setAlphaValue('hsla(240, 100%, 50%, 0.3)', 0.5)).toBe('hsla(240, 100%, 50%, 0.5)');
+    });
+
+    test('sets alpha value for HEX_ALPHA color', () => {
+        expect(setAlphaValue('#ff000080', 0.9)).toBe('#ff0000e6');
+        expect(setAlphaValue('#00ff004d', 0.7)).toBe('#00ff00b3');
+    });
+
+    test('sets alpha value for RGB color', () => {
+        expect(setAlphaValue('rgb(255, 0, 0)', 0.5)).toBe('rgba(255, 0, 0, 0.5)');
+        expect(setAlphaValue('rgb(0, 255, 0)', 0.8)).toBe('rgba(0, 255, 0, 0.8)');
+    });
+
+    test('sets alpha value for HSL color', () => {
+        expect(setAlphaValue('hsl(120, 100%, 50%)', 0.5)).toBe('hsla(120, 100%, 50%, 0.5)');
+        expect(setAlphaValue('hsl(240, 100%, 50%)', 0.8)).toBe('hsla(240, 100%, 50%, 0.8)');
+    });
+
+    test('sets alpha value for HEX color', () => {
+        expect(setAlphaValue('#ff0000', 0.5)).toBe('#ff000080');
+        expect(setAlphaValue('#00ff00', 0.8)).toBe('#00ff00cc');
+    });
+
+    test('sets alpha value for LAB color', () => {
+        expect(setAlphaValue('lab(50 40 30)', 0.5)).toBe('rgba(191, 88, 70, 0.5)');
+        expect(setAlphaValue('lab(75 -25 25)', 0.8)).toBe('rgba(154, 196, 138, 0.8)');
+    });
+
+    test('sets alpha value for LCH color', () => {
+        expect(setAlphaValue('lch(50 30 30)', 0.5)).toBe('rgba(167, 101, 95, 0.5)');
+        expect(setAlphaValue('lch(75 25 250)', 0.8)).toBe('rgba(137, 191, 227, 0.8)');
+    });
+
+    test('sets alpha value for NAMED color', () => {
+        expect(setAlphaValue('red', 0.5)).toBe('rgba(255, 0, 0, 0.5)');
+        expect(setAlphaValue('blue', 0.8)).toBe('rgba(0, 0, 255, 0.8)');
+    });
+
+    test('throws error for unsupported color format', () => {
+        expect(() => setAlphaValue('invalidColor', 0.5)).toThrow('Invalid color format invalidColor');
+    });
+
+    test('throws error for invalid alpha value', () => {
+        expect(() => setAlphaValue('rgba(255, 0, 0, 0.5)', 1.5)).toThrow('Invalid alpha value 1.5. Alpha should be between 0 and 1.');
+        expect(() => setAlphaValue('rgba(255, 0, 0, 0.5)', -0.1)).toThrow('Invalid alpha value -0.1. Alpha should be between 0 and 1.');
+    });
+});


### PR DESCRIPTION
Implemented the setAlphaValue function to set the alpha value of colors in various formats. Added comprehensive tests to ensure correct functionality and documented the usage in the API documentation. Exported the function in the main module.