### PR TITLE
fix: support optional alpha value in RGBA parsing

### DIFF
--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -7,6 +7,7 @@
  */
 export function parseComponent(value: string, asInteger?: boolean): number {
     if (value === 'none') return 0;
+    if (typeof value === 'undefined') return value;
     return asInteger ? parseInt(value, 10) : parseFloat(value);
 }
 
@@ -65,12 +66,15 @@ export function roundTo(num: number, precision: number = 3): number {
  */
 export function parseRgbComponent(value: string, isAlpha?: boolean): number {
     if (value === 'none') return isAlpha ? 1 : 0;
-    if (value.includes('%')) {
+    if (value?.includes('%')) {
         const percentValue = parseFloat(value) * (isAlpha ? 0.01 : 2.55);
         const result = (percentValue * 100) / 100;
         return isAlpha ? result : Math.round(result);
     }
 
-    if (isAlpha) return parseFloat(value);
+    if (isAlpha) {
+        if (typeof value === 'undefined') return value;
+        return parseFloat(value);
+    }
     return parseInt(value, 10);
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -16,7 +16,10 @@ export const lchRegex: RegExp =
 
 export const rgbRegex: RegExp = /^rgb\(\s*(\d{1,3}(%)?)\s*,\s*(\d{1,3}(%)?)\s*,\s*(\d{1,3}(%)?)\s*\)$/i;
 
+// export const rgbaRegex: RegExp =
+//     /^rgba\(\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*,\s*(none|0|1|0?\.\d+|\d{1,3}(%)?)\s*\)$/i;
+
 export const rgbaRegex: RegExp =
-    /^rgba\(\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*,\s*(none|0|1|0?\.\d+|\d{1,3}(%)?)\s*\)$/i;
+    /^rgba\(\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*,\s*(\d{1,3}(%)?|none)\s*(?:,\s*(none|0|1|0?\.\d+|\d{1,3}(%)?)\s*)?\)$/i;
 
 export const xyzRegex: RegExp = /^xyz\(\s*(-?\d+(\.\d+)?)\s*,\s*(-?\d+(\.\d+)?)\s*,\s*(-?\d+(\.\d+)?)\s*\)$/;

--- a/src/validations/isValidRgba.ts
+++ b/src/validations/isValidRgba.ts
@@ -16,7 +16,7 @@ export function isValidRgba(color: string): boolean {
     if (!match) return false;
 
     const isValidComponent = (value: number, isAlpha?: boolean) => {
-        if (isAlpha) return value >=0 && value <= 1;
+        if (isAlpha) return (typeof value === 'undefined') || (value >=0 && value <= 1);
         return value >= 0 && value <= 255;
     }
 

--- a/tests/parser/parseRgba.test.ts
+++ b/tests/parser/parseRgba.test.ts
@@ -2,7 +2,7 @@ import { parseRgba } from '@/parser/parseRgba';
 
 describe('parseRgba', () => {
     test('parses RGBA color with numbers correctly', () => {
-        const result = parseRgba('rgba(255, 0, 0, 0.5)');
+        const result = parseRgba('rgba(255, 0, 0)');
         expect(result).toEqual({
             r: 255,
             rUnit: undefined,
@@ -13,9 +13,9 @@ describe('parseRgba', () => {
             b: 0,
             bUnit: undefined,
             bNum: 0,
-            a: 0.5,
+            a: undefined,
             aUnit: undefined,
-            aNum: 0.5,
+            aNum: undefined,
         });
     });
 


### PR DESCRIPTION
Update `parseRgba` function and related utils to handle RGBA strings with optional alpha values. Adjusted tests, regex, and validations to reflect these changes.