### PR TITLE
docs: update documentation link style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ console.log(isValidLab('lab(50% 0% 0%)')); // Output: true
 
 <p>See all <a href="https://colore.mallikcheripally.com/docs/api/validations/isValidHex">Validations</a>.</p>
 
-> See **[Documentation](https://colore.mallikcheripally.com)** for complete API reference.
+> #### See **[Documentation](https://colore.mallikcheripally.com)** for complete API reference.
 
 ### Supported Color Formats
 

--- a/README.md
+++ b/README.md
@@ -471,19 +471,19 @@ console.log(isValidLab('lab(50% 0% 0%)')); // Output: true
 
 ### Supported Color Formats
 
-| Format    | String Format | Object Format |
-|-----------|---------------|---------------|
-| Hex       | ✅ Yes         | ❌ No          |
-| Hex Alpha | ✅ Yes           | ❌ No          |
-| HSL       | ✅ Yes           | ✅ Yes           |
-| HSLA      | ✅ Yes           | ✅ Yes           |
-| HSV       | ✅ Yes           | ✅ Yes           |
-| LAB       | ✅ Yes           | ✅ Yes           |
-| LCH       | ✅ Yes           | ✅ Yes           |
-| Named     | ✅ Yes           | ✅ Yes           |
-| RGB       | ✅ Yes           | ✅ Yes           |
-| RGBA      | ✅ Yes           | ✅ Yes           |
-| XYZ       | ✅ Yes           | ✅ Yes           |
+| Format    | As String | As Object |
+|-----------|------------------|-----------|
+| Hex       | ✅ Yes            | ❌ No      |
+| Hex Alpha | ✅ Yes            | ❌ No      |
+| HSL       | ✅ Yes            | ✅ Yes     |
+| HSLA      | ✅ Yes            | ✅ Yes     |
+| HSV       | ✅ Yes            | ✅ Yes     |
+| LAB       | ✅ Yes            | ✅ Yes     |
+| LCH       | ✅ Yes            | ✅ Yes     |
+| Named     | ✅ Yes            | ✅ Yes     |
+| RGB       | ✅ Yes            | ✅ Yes     |
+| RGBA      | ✅ Yes            | ✅ Yes     |
+| XYZ       | ✅ Yes            | ✅ Yes     |
 
 ### Contributing
 


### PR DESCRIPTION
Changed the documentation link style to a sub-header for better visibility. This makes the README more consistent and navigable for users seeking the API reference.